### PR TITLE
Fix label parenting

### DIFF
--- a/TooManySuits/Plugin.cs
+++ b/TooManySuits/Plugin.cs
@@ -86,6 +86,7 @@ public class TooManySuits : MonoBehaviour
 
         SuitRackPrefab = Instantiate(prefab);
         SuitRackPrefab.SetActive(false);
+        SuitRackPrefab.AddComponent<AutoParentToShip>();
         
         SuitRackPrefab.hideFlags = HideFlags.HideAndDontSave;
         DontDestroyOnLoad(SuitRackPrefab);


### PR DESCRIPTION
Fixes a bug where the label would:
- appear at the landing location before the ship finished landing.
- stay at the landing location after taking off.